### PR TITLE
Fix secondary meta key

### DIFF
--- a/includes/class-genesis-simple-menus-entry.php
+++ b/includes/class-genesis-simple-menus-entry.php
@@ -37,7 +37,7 @@ class Genesis_Simple_Menus_Entry {
 	 *
 	 * @var string
 	 */
-	public $secondary_key = '_gsm_secondary';
+	public $secondary_key = '_gsm_menu';
 
 	/**
 	 * The nonce action for saving entry meta.
@@ -125,8 +125,8 @@ class Genesis_Simple_Menus_Entry {
 			// phpcs:ignore
 			$_POST['genesis_simple_menus'],
 			array(
-				'_gsm_primary'   => '',
-				'_gsm_secondary' => '',
+				'_gsm_primary' => '',
+				'_gsm_menu'    => '',
 			)
 		);
 

--- a/includes/class-genesis-simple-menus-term.php
+++ b/includes/class-genesis-simple-menus-term.php
@@ -35,7 +35,7 @@ class Genesis_Simple_Menus_Term {
 	 *
 	 * @var string
 	 */
-	public $secondary_key = '_gsm_secondary';
+	public $secondary_key = '_gsm_menu';
 
 	/**
 	 * The supported taxonomies.

--- a/includes/views/term-edit-field.php
+++ b/includes/views/term-edit-field.php
@@ -18,7 +18,7 @@ $secondary_label = $menus[0]['secondary'];
 			<label for="genesis-meta[<?php echo esc_attr( $this->primary_key ); ?>]"><span><?php echo esc_html( $primary_label ); ?><span></label>
 		</th>
 		<td>
-			<select name="genesis-meta[<?php echo esc_attr( $this->meta_key ); ?>]" id="genesis-meta[<?php echo esc_attr( $this->meta_key ); ?>]">
+			<select name="genesis-meta[<?php echo esc_attr( $this->primary_key ); ?>]" id="genesis-meta[<?php echo esc_attr( $this->primary_key ); ?>]">
 				<option value=""><?php esc_html_e( 'Default', 'genesis-simple-menus' ); ?></option>
 				<?php
 				$menus = wp_get_nav_menus(
@@ -27,7 +27,7 @@ $secondary_label = $menus[0]['secondary'];
 					)
 				);
 				foreach ( $menus as $menu_entry ) {
-					printf( '<option value="%d" %s>%s</option>', esc_attr( $menu_entry->term_id ), selected( $menu_entry->term_id, get_term_meta( $term->term_id, $this->meta_key, true ), false ), esc_html( $menu_entry->name ) );
+					printf( '<option value="%d" %s>%s</option>', esc_attr( $menu_entry->term_id ), selected( $menu_entry->term_id, get_term_meta( $term->term_id, $this->primary_key, true ), false ), esc_html( $menu_entry->name ) );
 				}
 				?>
 			</select>
@@ -38,7 +38,7 @@ $secondary_label = $menus[0]['secondary'];
 			<label for="genesis-meta[<?php echo esc_attr( $this->secondary_key ); ?>]"><span><?php echo esc_html( $secondary_label ); ?><span></label>
 		</th>
 		<td>
-			<select name="genesis-meta[<?php echo esc_attr( $this->meta_key ); ?>]" id="genesis-meta[<?php echo esc_attr( $this->meta_key ); ?>]">
+			<select name="genesis-meta[<?php echo esc_attr( $this->secondary_key ); ?>]" id="genesis-meta[<?php echo esc_attr( $this->secondary_key ); ?>]">
 				<option value=""><?php esc_html_e( 'Default', 'genesis-simple-menus' ); ?></option>
 				<?php
 				$menus = wp_get_nav_menus(
@@ -47,7 +47,7 @@ $secondary_label = $menus[0]['secondary'];
 					)
 				);
 				foreach ( $menus as $menu_entry ) {
-					printf( '<option value="%d" %s>%s</option>', esc_attr( $menu_entry->term_id ), selected( $menu_entry->term_id, get_term_meta( $term->term_id, $this->meta_key, true ), false ), esc_html( $menu_entry->name ) );
+					printf( '<option value="%d" %s>%s</option>', esc_attr( $menu_entry->term_id ), selected( $menu_entry->term_id, get_term_meta( $term->term_id, $this->secondary_key, true ), false ), esc_html( $menu_entry->name ) );
 				}
 				?>
 			</select>


### PR DESCRIPTION
**Summary of change:**
Restores the secondary menu meta key back to `_gsm_menu` to prevent users options from being lost during an update.

**Have the changes in this PR been added to the documentation for this project?**
No

**How to test:**
Reset to 1.0.0 tag and assign a menu. Switch to the latest branch and check that the settings were carried over.

<!-- If this PR is in reference to an existing issue, link it here. -->
**See:** #7

<!-- If this PR fully resolves an existing issue, link it here. -->
**Fixes:** #7

> If a person is running version 1.0.1 of this plugin, and updates to 1.1.0 (with these changes), will they lose their currently assigned entry menus? It looks like you've changed the key on the postmeta that gets saved.

**Suggested Changelog Entry:**
Fixes secondary menu meta key being lost in version update
