### PR TITLE
Verify if primary and secondary menus entries are not empty

### DIFF
--- a/includes/class-genesis-simple-menus-core.php
+++ b/includes/class-genesis-simple-menus-core.php
@@ -83,8 +83,15 @@ class Genesis_Simple_Menus_Core {
 	public function menu_locations_theme_mod( $mods ) {
 
 		if ( $this->primary || $this->secondary ) {
-			$mods['primary']   = (int) $this->primary;
-			$mods['secondary'] = (int) $this->secondary;
+			if ( $this->primary || $this->secondary ) {
+				if ( ! empty( $this->primary ) ) {
+					$mods['primary'] = (int) $this->primary;
+				}
+
+				if ( ! empty( $this->secondary ) ) {
+					$mods['secondary'] = (int) $this->secondary;
+				}
+			}
 		}
 
 		return $mods;


### PR DESCRIPTION
The version 1.1.0 has brought a new option to add a secondary menu. This feature introduced a bug where the main menu (e.g. default by the theme) was being filled with a blank menu. This PR should fix this issue.

See #16 
Closes #16 
