### PR TITLE
Use an image with a secure version of `curl`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
-      - checkout
       - run:
           name: Install Composer
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ jobs:
             rm composer-setup.php
             composer config -g github-protocols https && composer config -g repo.packagist composer https://packagist.org
       - install_dependencies
-      - run: php -i
       - run: composer phpcs
 
   deploy_svn_branch:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,9 @@ executors:
     docker:
       - image: cimg/base:current
     working_directory: /tmp
-  php_node:
+  php:
     docker:
-      - image: cimg/php:8.2-node
+      - image: wordpress:php8.2-fpm-alpine
     working_directory: /tmp/src
 
 jobs:
@@ -82,10 +82,24 @@ jobs:
             - src
 
   checks:
-    executor: php_node
+    executor: php
     steps:
       - attach_workspace:
           at: /tmp
+      - checkout
+      - run:
+          name: Install Composer
+          command: |
+            mkdir -p ~/project/bin
+            cd ~/project/bin
+            echo 'export PATH=$HOME/project/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+            EXPECTED_SIGNATURE=$(curl -s https://composer.github.io/installer.sig)
+            ACTUAL_SIGNATURE=$(php -r "echo hash_file('sha384', 'composer-setup.php');")
+            [[ "$EXPECTED_SIGNATURE" == "$ACTUAL_SIGNATURE" ]] && php composer-setup.php --install-dir=/root/project/bin --filename=composer || exit 1
+            rm composer-setup.php
+            composer config -g github-protocols https && composer config -g repo.packagist composer https://packagist.org
       - install_dependencies
       - run: php -i
       - run: composer phpcs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
       - attach_workspace:
           at: /tmp
       - install_dependencies
+      - run: php -i
       - run: composer phpcs
 
   deploy_svn_branch:

--- a/genesis-simple-menus.php
+++ b/genesis-simple-menus.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'GENESIS_SIMPLE_MENU_SETTINGS_FIELD', 'genesis_simple_menu_settings' );
-define( 'GENESIS_SIMPLE_MENU_VERSION', '1.1.1' );
+define( 'GENESIS_SIMPLE_MENU_VERSION', '1.1.2' );
 define( 'GENESIS_SIMPLE_MENU_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GENESIS_SIMPLE_MENU_PLUGIN_URL', plugins_url( '', __FILE__ ) );
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "description": "Genesis Simple Menus allows you to select a WordPress menu for secondary navigation on individual posts/pages.",
     "author": "StudioPress",
     "authoruri": "http://www.studiopress.com/",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "license": "GPL-2.0-or-later",
     "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "genesis-simple-menus"

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpmuguru, nathanrice, studiopress, seothemes, marksabbath
 Tags: genesis,genesiswp,studiopress,menu,navigation
 Requires at least: 4.4.2
 Tested up to: 6.3
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 Requires PHP: 8.1
 
 With Genesis, Simple Menus allows you to select a WP menu for secondary navigation on posts, pages, categories, tags or custom taxonomies.
@@ -24,6 +24,9 @@ This plugin allows you to assign WordPress navigation menus to the secondary nav
 1. Choose the menu you want to display by choosing it from the drop-down menu in the post/page or category/tag edit screen.
 
 == Changelog ==
+
+= 1.1.2 =
+* Bump the minimum required PHP version to 8.1.
 
 = 1.1.1 =
 * Fix issue where menus were not displaying when set to the default option.

--- a/simple-menu.php
+++ b/simple-menu.php
@@ -3,7 +3,7 @@
  * Plugin Name: Genesis Simple Menus
  * Plugin URI: https://github.com/studiopress/genesis-simple-menus/
  * Description: Genesis Simple Menus allows you to select a WordPress menu for secondary navigation on individual posts, pages, and taxonomies.
- * Version: 1.1.1
+ * Version: 1.1.2
  * Author: StudioPress
  * Author URI: https://www.studiopress.com/
  * License: GNU General Public License v2.0 (or later)


### PR DESCRIPTION
Uses an image with a [secure version](https://app.circleci.com/pipelines/github/studiopress/genesis-simple-menus/34/workflows/795c6162-64d5-4aed-b8f4-333451d38043/jobs/80?invite=true#step-105-6537_25) of `curl`: `8.4.0`

Fixes [GF-3880](https://wpengine.atlassian.net/browse/GF-3880)


### How to test
Not needed