### PR TITLE
[LOC-6423] Ensure compatibility with Genesis 3.6

### DIFF
--- a/includes/class-genesis-simple-menus.php
+++ b/includes/class-genesis-simple-menus.php
@@ -76,7 +76,7 @@ final class Genesis_Simple_Menus {
 		/**
 		 * Include and Instantiate.
 		 */
-		add_action( 'genesis_setup', array( $this, 'instantiate' ) );
+		add_action( 'after_setup_theme', array( $this, 'instantiate' ), 11 );
 	}
 
 

--- a/includes/class-genesis-simple-menus.php
+++ b/includes/class-genesis-simple-menus.php
@@ -116,6 +116,10 @@ final class Genesis_Simple_Menus {
 	 */
 	public function instantiate() {
 
+		if ( ! function_exists( 'genesis_nav_menu_supported' ) ) {
+			return;
+		}
+
 		// Do nothing if secondary menu isn't supported.
 		if ( ! genesis_nav_menu_supported( 'secondary' ) ) {
 			return;


### PR DESCRIPTION
Adjusts initialisation order so the plugin loads again under Genesis 3.6+.

### Background

This plugin lets users override the default menus that appear in the primary menu location (typically the site header) and secondary menu location (typically site footer) on a per-page basis:

![CleanShot 2025-04-10 at 11 13 02@2x](https://github.com/user-attachments/assets/a97ff0af-8a6b-4307-bee7-2be9d5cec6bf)

For example, a user might want to toggle the site footer menu to display a custom one on a landing page.

### Why this broke in Genesis 3.6

Genesis 3.6 deferred loading of menu registration until `after_setup_theme` to ensure translations load at the correct time and to prevent "doing it wrong" PHP notices.

Genesis Simple Menus no longer works after that change — the "Navigation" box in the editor is missing.

### What this PR does

Loads plugin init logic a little later, in `after_setup_theme`, after Genesis has registered menus.

### How to test

1. Set up a site in Local with Genesis 3.6 and Genesis Sample 3.4.3. (See [attached files in Slack](https://wpengine.slack.com/archives/C019UA40QE8/p1744278440739049).)
2. Activate Genesis Sample from Appearance → Themes and go through the one-click theme setup.
3. Download Genesis Simple Menus built from this PR, then install and activate it: [genesis-simple-menus.1.1.3.zip](https://github.com/user-attachments/files/19682249/genesis-simple-menus.1.1.3.zip)
4. Create a new menu at Appearance → Menus and give it at least one menu item.
5. Edit an existing page, such as "About". You should see a "Navigation" box in the bottom-right of the editor as pictured above.
6. If you change either menu in the Navigation area and save, you should see that menu when you visit the frontend of the site.

I also did the above under Genesis 3.5 and found no regressions.

### Documentation

No documentation required.