### PR TITLE
[LOC-6437] Fix term menus to display saved term

### DIFF
--- a/includes/class-genesis-simple-menus-term.php
+++ b/includes/class-genesis-simple-menus-term.php
@@ -100,14 +100,12 @@ class Genesis_Simple_Menus_Term {
 	 *
 	 * @since  1.0.0
 	 *
-	 * @param  string $term     The term ID.
-	 * @param  string $taxonomy Current taxonomy.
+	 * @param  WP_Term $term     The term object.
+	 * @param  string  $taxonomy Current taxonomy.
 	 *
 	 * @return void
 	 */
-	public function term_edit_form( $term, $taxonomy ) {
-		unset( $term, $taxonomy );
-
+	public function term_edit_form( $term, $taxonomy ) { // phpcs:ignore -- $term is used in the included template.
 		require_once GENESIS_SIMPLE_MENU_PLUGIN_DIR . '/includes/views/term-edit-field.php';
 	}
 }


### PR DESCRIPTION
Restores selected term menus so saved values appear as selected in the drop-down, instead of 'default' after saving a custom value:

| Before | After |
| - | - |
| <img width="587" alt="image" src="https://github.com/user-attachments/assets/50ae8578-61eb-4ef3-a2e9-39684713a6f9" /> | <img width="567" alt="image" src="https://github.com/user-attachments/assets/d491528f-6e0c-4b17-b925-be2468f03d00" /> |

### Root cause
In #26, we stripped `$term` from `term_edit_form` to work around a phpcs warning about unused arguments:

https://github.com/studiopress/genesis-simple-menus/pull/26/files#diff-d27338949948e867d1f6cb42c1f46c0fc668e9dcc90a93789a73d3c42dc46164R109

But the $term argument is not unused. We use it in `term-edit-field.php` in the `selected()` call to determine the selected/saved value in the drop-down:

https://github.com/studiopress/genesis-simple-menus/blob/ad753d82568c0c67764219c79b01dee7bacc716e/includes/views/term-edit-field.php#L29-L31

https://github.com/studiopress/genesis-simple-menus/blob/ad753d82568c0c67764219c79b01dee7bacc716e/includes/views/term-edit-field.php#L49-L51

Stripping it results in menus being saved but the saved one not being selected as active when the page refreshes.

This PR adds a phpcs:ignore comment instead of using `unset()`, so that phpcs is happy and functionality is not affected.


### How to test
(With Genesis Sample and the plugin from this branch active — no `npm` or `composer` build steps required.)

1. Visit Posts → Categories and edit the “Uncategorized” category.
2. Under "Navigation", select a non-default value for the Header and Footer menus.
3. Save your changes.

You should see the values you selected after refreshing the page, instead of ‘default’.

### Documentation

I edited #31 to add this to the changelog.
