### PR TITLE
CI: fix plugin version detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ commands:
     steps:
       - run:
           command: |
-            echo "export VERSION=$(grep 'Version:' /tmp/src/simple-menu.php | awk -F: '{print $2}' | tr -d ' ')" >> ${BASH_ENV}"
+            echo "export VERSION=$(grep 'Version:' /tmp/src/simple-menu.php | awk -F: '{print $2}' | tr -d ' ')" >> ${BASH_ENV}
+            source ${BASH_ENV}
+            echo "VERSION set to: ${VERSION}"
 
   show_pwd_info:
     description: "Show information about the current directory"
@@ -108,6 +110,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp
+      - set_version_variable
       - run:
           name: Run phpcs
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     steps:
       - run:
           command: |
-            echo "export VERSION=$(grep 'Version:' /tmp/src/simple-menu.php | awk -F: '{print $2}' | tr -d ' ')" >> ${BASH_ENV}
+            echo "export VERSION=$(awk '$2 == "Version:" {print $3}' /tmp/src/simple-menu.php)" >> ${BASH_ENV}
             source ${BASH_ENV}
             echo "VERSION set to: ${VERSION}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     steps:
       - run:
           command: |
-            echo "export VERSION=$(grep 'Version:' /tmp/src/genesis-simple-menus.php | awk -F: '{print $2}' | sed 's/^\s//')" >> ${BASH_ENV}
+            echo "export VERSION=$(grep 'Version:' /tmp/src/simple-menu.php | awk -F: '{print $2}' | tr -d ' ')" >> ${BASH_ENV}"
 
   show_pwd_info:
     description: "Show information about the current directory"


### PR DESCRIPTION
So that the correct version number is used later in the pipeline during SVN deploy.

It looks like it's been reading the wrong file for the version number for [~5 years](https://github.com/studiopress/genesis-simple-menus/commit/647cadd3f807eee6f10631d329c470a84a9723ec). The original file mentioned, `genesis-simple-menus.php`, does not have a 'Version' header. The plugin header is in `simple-menu.php`.

Also switches from single space to multi-space replacements for robustness, and outputs detected version in CI for help with debugging.

### How to test

Check the ['version' output](https://app.circleci.com/pipelines/github/studiopress/genesis-simple-menus/73/workflows/344a59dc-e4a8-444e-aa51-9db4273a3de1/jobs/186) I added to the 'checks' job in Circle. 

![CleanShot 2025-04-15 at 14 31 00@2x](https://github.com/user-attachments/assets/8b5fa705-2efd-467b-bc0d-e593de18ce8a)

The new command should also give you a version number locally on macOS:

```sh 
> grep 'Version:' /tmp/src/simple-menu.php | awk -F: '{print $2}' | tr -d ' '
1.1.4
```

Previously the command was setting `VERSION` to an empty value due to genesis-simple-menus.php having no 'Version' content:

```sh
> grep 'Version:' genesis-simple-menus.php | awk -F: '{print $2}' | sed 's/^\s//'
[no output]
```
