### PR TITLE
Fix SVN deploys to WP.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,68 +1,35 @@
 version: 2.1
 
 orbs:
-  wp-svn: studiopress/wp-svn@0.1
+  wp-svn: studiopress/wp-svn@0.2
   node: circleci/node@7.1.0
 
-commands:
-  mkdir_artifacts:
-    description: "Make Artifacts directory"
-    steps:
-      - run:
-          command: |
-            [ ! -d "/tmp/artifacts" ] && mkdir /tmp/artifacts &>/dev/null
+executors:
+  base:
+    docker:
+      - image: cimg/base:current
+    working_directory: ~/project
+  php:
+    docker:
+      - image: cimg/php:8.2-node
+    working_directory: ~/project
 
+commands:
   set_version_variable:
     description: "Set the VERSION environment variable"
     steps:
       - run:
           command: |
-            echo "export VERSION=$(awk '$2 == "Version:" {print $3}' /tmp/src/simple-menu.php)" >> ${BASH_ENV}
+            echo "export VERSION=$(awk '$2 == "Version:" {print $3}' ~/project/genesis-simple-menus/simple-menu.php)" >> ${BASH_ENV}
             source ${BASH_ENV}
             echo "VERSION set to: ${VERSION}"
-
-  show_pwd_info:
-    description: "Show information about the current directory"
-    steps:
-      - run: pwd
-      - run: ls -lash
-
-  svn_setup:
-    description: "Setup SVN"
-    steps:
-      - run: echo "export SLUG=$(grep '@package' /tmp/src/genesis-simple-menus.php | awk -F ' ' '{print $3}' | sed 's/^\s//')" >> ${BASH_ENV}
-      - run: svn co https://plugins.svn.wordpress.org/${SLUG} --depth=empty .
-      - run: svn up trunk
-      - run: svn up tags --depth=empty
-      - run: find ./trunk -not -path "./trunk" -delete
-      - run: cp -r /tmp/src/. ./trunk
-      - run: svn propset svn:ignore -F ./trunk/.svnignore ./trunk
-
-  svn_add_changes:
-    description: "Add changes to SVN"
-    steps:
-      - run:
-          command: if [[ ! -z $(svn st | grep ^\!) ]]; then svn st | grep ^! | awk '{print " --force "$2}' | xargs -0r svn rm; fi
-      - run: svn add --force .
-
-  svn_create_tag:
-    description: "Create a SVN tag"
-    steps:
-      - set_version_variable
-      - run: svn cp trunk tags/${VERSION}
-
-  svn_commit:
-    description: "Commit changes to SVN"
-    steps:
-      - set_version_variable
-      - run: svn ci -m "Tagging ${VERSION} from Github" --no-auth-cache --non-interactive --username "${SVN_USERNAME}" --password "${SVN_PASSWORD}"
 
   create_zip_artifacts:
     description: "Create zip artifacts for WP.org (for testing) and WPE (manual deployment)"
     steps:
       - node/install
       - node/install-packages:
-          app-dir: /tmp/src
+          app-dir: ~/project/genesis-simple-menus
           override-ci-command: npm install
       - run:
           name: Install WP-CLI
@@ -75,77 +42,62 @@ commands:
       - run:
           name: Create zips and info.json
           command: |
-            cd /tmp/src
+            cd ~/project/genesis-simple-menus
             echo "Node.js version: $(node --version)"
             echo "npm version: $(npm --version)"
             npm run zip:all
       - store_artifacts:
-          path: /tmp/src/artifacts
+          path: ~/project/genesis-simple-menus/artifacts
           destination: artifacts
-
-executors:
-  base:
-    docker:
-      - image: cimg/base:current
-    working_directory: /tmp
-  php:
-    docker:
-      - image: cimg/php:8.2-node
-    working_directory: /tmp/src
 
 jobs:
   checkout:
     executor: base
     steps:
-      - mkdir_artifacts
       - checkout:
-          path: src
+          path: genesis-simple-menus
       - persist_to_workspace:
-          root: /tmp
+          root: ~/project
           paths:
-            - src
+            - genesis-simple-menus
 
   checks:
     executor: php
     steps:
       - attach_workspace:
-          at: /tmp
+          at: ~/project
       - set_version_variable
       - run:
           name: Run phpcs
           command: |
-            cd /tmp/src
+            cd ~/project/genesis-simple-menus
             echo "Composer version: $(composer --version)"
             composer install
             composer phpcs
-
-  deploy_svn_branch:
-    executor: base
-    working_directory: /tmp/artifacts
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - svn_setup
-      - svn_add_changes
-      - svn_commit
-
-  deploy_svn_tag:
-    executor: base
-    working_directory: /tmp/artifacts
-    steps:
-      - attach_workspace:
-          at: /tmp
-      - svn_setup
-      - svn_create_tag
-      - svn_add_changes
-      - svn_commit
 
   create_artifacts:
     executor: php
     steps:
       - attach_workspace:
-          at: /tmp
+          at: ~/project
       - create_zip_artifacts
+
+  svn_dry_run:
+    executor: base
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - wp-svn/deploy-plugin:
+          plugin-path: genesis-simple-menus
+          dry-run: true
+
+  deploy:
+    executor: base
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - wp-svn/deploy-plugin:
+          plugin-path: genesis-simple-menus
 
 workflows:
   version: 2
@@ -166,6 +118,13 @@ workflows:
       - create_artifacts:
           requires:
             - checkout
+          filters:
+            branches:
+              ignore:
+                - master
+      - svn_dry_run:
+          requires:
+            - checks
           filters:
             branches:
               ignore:
@@ -205,7 +164,7 @@ workflows:
             branches:
               only:
                 - master
-      - deploy_svn_branch:
+      - deploy:
           context: genesis-svn
           requires:
             - checks
@@ -238,10 +197,17 @@ workflows:
               only: /^\d+\.\d+\.\d+$/
             branches:
               ignore: /.*/
-      - deploy_svn_tag:
+      - wp-svn/check-versions:
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+            branches:
+              ignore: /.*/
+      - deploy:
           context: genesis-svn
           requires:
             - checks
+            - wp-svn/check-versions
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/

--- a/.distignore
+++ b/.distignore
@@ -2,7 +2,7 @@
 .git
 .gitignore
 .gitattributes
-.svnignore
+.distignore
 .nvmrc
 .circleci/
 .DS_Store

--- a/readme.txt
+++ b/readme.txt
@@ -30,7 +30,7 @@ This plugin allows you to assign WordPress navigation menus to the secondary nav
 * Fix term Navigation drop-downs to display selected menus.
 
 = 1.1.3 =
-* Genesis Simple Menus now uses its own update mechanism from WP Engine servers.
+* Genesis Simple Menus now uses its own update mechanism from WP Engine servers (except for the version deployed to WP.org).
 
 = 1.1.2 =
 * Bump the minimum required PHP version to 8.1.

--- a/scripts/create-zip.js
+++ b/scripts/create-zip.js
@@ -40,7 +40,7 @@ function ensureBuildDirectory(wpe = false) {
 }
 
 function getIgnorePatterns() {
-	const distignore = fs.readFileSync(".svnignore", "utf8");
+	const distignore = fs.readFileSync(".distignore", "utf8");
 	return distignore
 		.split("\n")
 		.map((line) => line.trim())


### PR DESCRIPTION
In response to [recent deploy failure](https://github.com/studiopress/genesis-simple-menus/pull/34#:~:text=https%3A//app.circleci.com/pipelines/github/studiopress/genesis%2Dsimple%2Dmenus/76/workflows/0073aca5%2D2284%2D48f4%2D866f%2D2f8cf81773e9/jobs/196) from the existing SVN deployment config:

- Use updated SVN deployment orb.
- Adjust Circle deploy process to better match Genesis Blocks.
- Add an SVN dry-run step so we can see what will change on each commit before tagging a release to publish to WP.org.

See commit message for more.

### How to test
1. Check [artifacts in Circle](https://app.circleci.com/pipelines/github/studiopress/genesis-simple-menus/81/workflows/933b0e05-4ead-4ebc-9950-904f83bc475d/jobs/209/artifacts).
2. Check [dry-run svn diff under "preparing deployment"](https://circleci.com/gh/studiopress/genesis-simple-menus/211).

