### PR TITLE
chore: bump tested WP version to 7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "genesis-simple-menus",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genesis-simple-menus",
+      "version": "1.1.4",
       "devDependencies": {
         "adm-zip": "^0.5.16",
         "ajv": "^8.17.1",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wpmuguru, nathanrice, studiopress, seothemes, marksabbath
 Tags: genesis,genesiswp,studiopress,menu,navigation
 Requires at least: 4.4.2
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.1.4
 Requires PHP: 8.1
 

--- a/scripts/create-info.js
+++ b/scripts/create-info.js
@@ -133,6 +133,21 @@ async function createInfoJson() {
         info.requires = requiresMatch[1];
         info.tested = testedMatch[1];
         info.requires_php = requiresPhpMatch[1];
+        info.author_profile = info.author_profile ?? '';
+
+        // Normalize fields that the remote API may return in alternate shapes.
+        if (typeof info.author === 'object' && info.author !== null) {
+            info.author = info.author.display_name || info.author.name || '';
+        }
+        if (Array.isArray(info.contributors)) {
+            info.contributors = Object.fromEntries(
+                info.contributors.map(({ name, profile, avatar, display_name }) => [
+                    name,
+                    { profile, avatar, display_name },
+                ])
+            );
+        }
+        info.sections.reviews = info.sections.reviews ?? '';
 
         // Update changelog
         info.sections.changelog = changelogHtml;


### PR DESCRIPTION
Marks as tested with WP 7.

Adjusts WPE info.json generation to pass validation.